### PR TITLE
Highlight unit cell

### DIFF
--- a/index.html
+++ b/index.html
@@ -195,6 +195,9 @@
                   <div class="col-xs-6 col-sm-7 col-md-8">
                     <label class="radio-inline"><input type="radio" name="layout" value="riemann" checked>Riemannian</label>
                     <label class="radio-inline"><input type="radio" name="layout" value="sonome">Sonome</label>
+                    <div class="checkbox">
+                      <label><input name="show-unit-cell" id="show-unit-cell" type="checkbox"> Show unit cell</label>
+                    </div>
                   </div>
                 </div>
                 <div class="form-group">

--- a/index.html
+++ b/index.html
@@ -195,19 +195,19 @@
                   <div class="col-xs-6 col-sm-7 col-md-8">
                     <label class="radio-inline"><input type="radio" name="layout" value="riemann" checked>Riemannian</label>
                     <label class="radio-inline"><input type="radio" name="layout" value="sonome">Sonome</label>
-                    <div class="checkbox">
-                      <label><input name="show-unit-cell" id="show-unit-cell" type="checkbox"> Show unit cell</label>
-                    </div>
                   </div>
                 </div>
                 <div class="form-group">
-                  <label class="control-label col-xs-5 col-sm-4 col-md-3">Labels</label>
+                  <label class="control-label col-xs-5 col-sm-4 col-md-3">Show/hide</label>
                   <div class="col-xs-6 col-sm-7 col-md-8">
                     <div class="checkbox">
-                      <label><input name="show-note-names" id="show-note-names" type="checkbox" checked> Show tone names</label>
+                      <label><input name="show-note-names" id="show-note-names" type="checkbox" checked> Tone names</label>
                     </div>
                     <div class="checkbox">
-                      <label><input name="show-triad-names" id="show-triad-names" type="checkbox"> Show triad names</label>
+                      <label><input name="show-triad-names" id="show-triad-names" type="checkbox"> Triad names</label>
+                    </div>
+                    <div class="checkbox">
+                      <label><input name="show-unit-cell" id="show-unit-cell" type="checkbox"> Unit cell</label>
                     </div>
                   </div>
                 </div>
@@ -326,6 +326,8 @@
               <ul class="fa-ul">
                 <li><i class="fa-li fa fa-lg fa-flask"></i>Created by
                   <a href="https://ondrej.cifka.com" class="external" data-popup="true">Ondřej Cífka</a> in 2016</li>
+                <li><i class="fa-li fa fa-lg fa-users"></i>Contributions by
+                  <a href="https://github.com/Aknin" class="external" data-popup="true">Achille Aknin</a> and <a href="https://github.com/chumo" class="external" data-popup="true">Jesús Martínez-Blanco</a></li>
                 <li><i class="fa-li fa fa-lg fa-code"></i>Source code:
                   <a href="https://github.com/cifkao/tonnetz-viz" class="external" data-popup="true">GitHub</a></li>
                 <li><i class="fa-li fa fa-lg fa-youtube-play"></i>Videos:

--- a/js/main.js
+++ b/js/main.js
@@ -80,6 +80,10 @@ $(function(){
     window.open($(this)[0].href);
     event.preventDefault();
   });
+
+  $('#show-unit-cell').click(function() {
+    tonnetz.draw(true);
+  });
 });
 
 function collapseNav() {

--- a/js/main.js
+++ b/js/main.js
@@ -58,6 +58,7 @@ $(function(){
   $('#enable-sustain').click(function() { tonnetz.toggleSustainEnabled(); });
   $('#show-note-names').click(function() { $(noteLabels).toggle(); });
   $('#show-triad-names').click(function() { $(triadLabels).toggle(); });
+  $('#show-unit-cell').click(function() { tonnetz.toggleUnitCell(); });
   $('#ghost-duration').on('input change propertychange paste', function() {
     if(!tonnetz.setGhostDuration($(this).val())) {
       $(this).closest('.form-group').addClass('has-error');
@@ -79,10 +80,6 @@ $(function(){
   $('body').on('click', 'a[data-popup]', function(event) {
     window.open($(this)[0].href);
     event.preventDefault();
-  });
-
-  $('#show-unit-cell').click(function() {
-    tonnetz.draw(true);
   });
 });
 

--- a/js/tonnetz.js
+++ b/js/tonnetz.js
@@ -452,26 +452,19 @@ var tonnetz = (function() {
   };
 
   var drawUnitCell = function(ctx) {
-    var A = 9; // This is tone A
-
-    // to identify the closest A note to the center of the canvas
-    var distances = $.map(toneGrid[A], function(d){
-      return Math.sqrt((d.x - W/2)**2 + (d.y - H/2)**2);
-    });
-    // index of minimum distance
-    var i = distances.indexOf(Math.min.apply(Math, distances));
-    setTranslate(ctx, toneGrid[A][i].x, toneGrid[A][i].y);
+    var closest = getNeighborXYDiff(0,3);
+    setTranslate(ctx, W/2-closest.x, H/2-closest.y);
 
     ctx.beginPath();
     ctx.moveTo(0, 0);
     if (module.layout == LAYOUT_RIEMANN) {
-      ctx.lineTo(3.5*u, -SQRT_3*u/2);
+      ctx.lineTo(1.5*u, 3*SQRT_3*u/2);
+      ctx.lineTo(3.5*u, -1*SQRT_3*u/2);
       ctx.lineTo(2*u, -4*SQRT_3*u/2);
-      ctx.lineTo(-1.5*u, -3*SQRT_3*u/2);
     } else if (module.layout == LAYOUT_SONOME) {
-      ctx.lineTo(-SQRT_3*u/2, -3.5*u);
       ctx.lineTo(-2*SQRT_3*u, -2*u);
-      ctx.lineTo(-3*SQRT_3*u/2, 1.5*u);
+      ctx.lineTo(-3.5*SQRT_3*u, -0.5*u);
+      ctx.lineTo(-1.5*SQRT_3*u, 1.5*u);
     }
     ctx.lineTo(0, 0);
     ctx.strokeStyle = colorscheme.stroke[0];

--- a/js/tonnetz.js
+++ b/js/tonnetz.js
@@ -330,6 +330,11 @@ var tonnetz = (function() {
       }
     }
 
+    // Draw unit cell, if checkbox is checked.
+    if ($('#show-unit-cell').is(":checked")){
+      drawUnitCell(ctx);
+    };
+
     // Draw edges. Each vertex takes care of the three upward edges.
     for (var tone=0; tone<12; tone++) {
       var c = tones[tone].cache;
@@ -444,6 +449,34 @@ var tonnetz = (function() {
 
     // Add the node to the grid.
     toneGrid[tone].push(node);
+  };
+
+  var drawUnitCell = function(ctx) {
+    var A = 9; // This is tone A
+
+    // to identify the closest A note to the center of the canvas
+    var distances = $.map(toneGrid[A], function(d){
+      return Math.sqrt((d.x - W/2)**2 + (d.y - H/2)**2);
+    });
+    // index of minimum distance
+    var i = distances.indexOf(Math.min.apply(Math, distances));
+    setTranslate(ctx, toneGrid[A][i].x, toneGrid[A][i].y);
+
+    ctx.beginPath();
+    ctx.moveTo(0, 0);
+    if (module.layout == LAYOUT_RIEMANN) {
+      ctx.lineTo(3.5*u, -SQRT_3*u/2);
+      ctx.lineTo(2*u, -4*SQRT_3*u/2);
+      ctx.lineTo(-1.5*u, -3*SQRT_3*u/2);
+    } else if (module.layout == LAYOUT_SONOME) {
+      ctx.lineTo(-SQRT_3*u/2, -3.5*u);
+      ctx.lineTo(-2*SQRT_3*u, -2*u);
+      ctx.lineTo(-3*SQRT_3*u/2, 1.5*u);
+    }
+    ctx.lineTo(0, 0);
+    ctx.strokeStyle = colorscheme.stroke[0];
+    ctx.lineWidth = 4;
+    ctx.stroke();
   };
 
   module.rebuild = function() {

--- a/js/tonnetz.js
+++ b/js/tonnetz.js
@@ -19,6 +19,7 @@ var tonnetz = (function() {
   module.density = 22;
   module.ghostDuration = 500;
   module.layout = LAYOUT_RIEMANN;
+  module.unitCellVisible = false;
 
   var toneGrid = [];
   var tones;
@@ -186,6 +187,11 @@ var tonnetz = (function() {
     this.rebuild();
   };
 
+  module.toggleUnitCell = function() {
+    this.unitCellVisible = !this.unitCellVisible;
+    this.draw();
+  };
+
 
   var releaseTone = function(tone) {
     tone.release = new Date();
@@ -330,8 +336,7 @@ var tonnetz = (function() {
       }
     }
 
-    // Draw unit cell, if checkbox is checked.
-    if ($('#show-unit-cell').is(":checked")){
+    if (module.unitCellVisible){
       drawUnitCell(ctx);
     };
 

--- a/js/tonnetz.js
+++ b/js/tonnetz.js
@@ -256,7 +256,7 @@ var tonnetz = (function() {
 
     colorscheme.update();
 
-    var xUnit = u*Math.sqrt(3)/2;
+    var xUnit = u*SQRT_3/2;
     var uW = Math.ceil(Math.ceil(W/xUnit*2)/2);
     var uH = Math.ceil(H/u);
 


### PR DESCRIPTION
The tonnetz grid looks too similar everywhere across the plane, and it is hard to distinguish for example which major chord is being played (all show up as triangles pointing in the same direction). By being able to highlight the unit cell containing the 12 repeating notes, the user will have a visual anchor to help identify which precise note or chord is being played. For example, C major triad will be easily distinguishable from any other major triad. 
Highlighting the unit cell is optional and it is disabled by default. To enable it, a new item in the menu "Appearance -> Layout" has been added.